### PR TITLE
Add Clang check on CI

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,10 @@
+name: Clang Workflow
+on: pull_request
+
+jobs:
+  clang-check:
+    name: Clang-Formater action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ./ci/clang-formater

--- a/ci/clang-formater/Dockerfile
+++ b/ci/clang-formater/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:unstable-20211011-slim
+
+RUN  apt-get update && \
+apt-get install -y --no-install-recommends clang-format-13
+
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/ci/clang-formater/action.yml
+++ b/ci/clang-formater/action.yml
@@ -1,0 +1,28 @@
+name: "Clang-Formater"
+description: "Check if format is applied to your code"
+
+inputs:
+  workplace:
+    description: "workspace path"
+    required: true
+    default: "/github/workspace"
+  fallback:
+    description: "Fallback style, case no .clang-format exist"
+    required: true
+    default: "Google"
+  apply:
+    description: "Apply format. On CI is false"
+    required: true
+    default: "false"
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - --workplace ${{ inputs.workplace }}
+    - --fallback ${{ inputs.fallback }}
+    - --apply ${{ inputs.apply }}
+
+branding:
+  icon: "mic"
+  color: "purple"

--- a/ci/clang-formater/entrypoint.sh
+++ b/ci/clang-formater/entrypoint.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+CLANG_FORMAT_VERSION="13"
+
+
+function print_usage () {
+    echo "Usage:"
+    echo "    $0"
+    echo "   --workplace                        Workplace where to apply formater"
+    echo "   --fallback                         Fallback style format to be use: By default is Google"
+    echo "   --apply                            <true|false> If true, format the code. Default is false"
+    echo "   --help                             Print this page"
+    echo
+}
+
+function log_() {
+    echo "[$(basename "$0")] $*"
+}
+
+
+function clang_file() {
+
+    log_ "Run running clang on ${1}"
+
+    local files=$(find . -regex '.*\.\(cpp\|hpp\|h\|cc\|cxx\)'  | tr '\n' ' ')
+
+
+    /usr/bin/clang-format-${CLANG_FORMAT_VERSION} ${3} --style=file --fallback-style=${2} ${files} || local format_status=$?
+
+	if [[ "${format_status}" -ne 0 ]]; then
+		log_ "Run clang-format your code before commit"
+	fi
+
+	return ${format_status}
+
+}
+
+
+# Returns 0 (success) if no error occurs, 1 otherwise.
+function parse_opts () {
+    # Parse options
+    local opt
+    while [[ $# -gt 0 ]]; do
+    opt="$1"
+
+    case $opt in
+        --workplace)
+        workplace_path="$2"; shift
+        ;;
+        -h|--help)
+        print_usage; exit 0;
+        ;;
+        --fallback)
+        fallback_style="${2}"; shift
+        ;;
+        --apply)
+        flag_apply="$2"; shift
+        ;;
+        *)
+        log_ "Unrecognized option '$opt'."; exit 1
+        ;;
+    esac
+    shift
+    done
+}
+
+parse_opts ${@}
+
+
+# If the path is not defined, default to the current
+workplace_path="${workplace_path:-.}"
+
+# If the fallback style is not defined, default to Google
+fallback_style="${fallback_style:-Google}"
+
+# If the apply flag is not set, default to false
+flag_apply="${flag_apply:-false}"
+
+log_ "workplace_path: ${workplace_path}"
+log_ "fallback_style: ${fallback_style}"
+log_ "flag apply format: ${flag_apply}"
+
+
+cd ${workplace_path}
+
+
+if [[ ${flag_apply} == "true" ]]; then
+    opt="-i --verbose"
+    clang_file ${workplace_path} ${fallback_style} "${opt}" || exit_code=$?
+else
+    opt="-n --Werror"
+    clang_file ${workplace_path} ${fallback_style} "${opt}" || exit_code=$?
+fi
+
+log_ "Job Completed"
+
+exit ${exit_code}


### PR DESCRIPTION
It is highly recommended to format your changed C++ code before opening pull requests, which will save you and the reviewers' time.

To apply format localy:
`./ci/clang-formater/entrypoint.sh --workplace ./src/ --apply true`